### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install Gems from private repository
 
 Add following line to `Gemfile`:
 
-    source 'hhttp://USERNAME:PASSWORD@HOST:9292'
+    source 'http://USERNAME:PASSWORD@HOST:9292'
 
 Proxy to RubyGems
 -----------------
@@ -71,6 +71,7 @@ If you mount data, when you stop, destroy your container and then run it, data a
 
 If you wan't to use different configuration for authentication, mount config folder containing your own config.ru
 Check [Geminabox Wiki](https://github.com/geminabox/geminabox/wiki/Http-Basic-Auth)
+
 
 ### Logs
 


### PR DESCRIPTION
Update README to fix typo in source example under 'Install Gems from private repository' and fix typo to make 'Logs' a header